### PR TITLE
Fix kNN benchmark KMNIST accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Have more results to add to the table? Feel free to submit an [issue](https://gi
 
 |Model                            | MNIST | Kuzushiji-MNIST | Kuzushiji-49 | Credit
 |---------------------------------|-------|--------|-----|---|
-|[4-Nearest Neighbour Baseline](benchmarks/kuzushiji_mnist_knn.py)     |97.14% | 91.56% | 86.01%|
+|[4-Nearest Neighbour Baseline](benchmarks/kuzushiji_mnist_knn.py)     |97.14% | 92.10% | 86.01%|
 |[Tuned SVM (RBF kernel)](https://github.com/rois-codh/kmnist/issues/3) | 98.57% | 92.82% | | [TomZephire](https://github.com/TomZephire)
 |[Keras Simple CNN Benchmark](benchmarks/kuzushiji_mnist_cnn.py)       |99.06% | 95.12% |89.25%|
 |PreActResNet-18                  |99.56% | 97.82% |96.64%|

--- a/benchmarks/kuzushiji_mnist_knn.py
+++ b/benchmarks/kuzushiji_mnist_knn.py
@@ -1,5 +1,5 @@
 # kNN with neighbors=4 benchmark for Kuzushiji-MNIST
-# Acheives 97.4% test accuracy
+# Acheives 92.10% test accuracy
 
 from sklearn.neighbors import KNeighborsClassifier
 import numpy as np


### PR DESCRIPTION
The benchmark accuracy for kNN classifier with `neighbors=4` gives test accuracy of `92.10%`, not `91.56%` as is currently shown in the results table from README:

```console
C:\...\kmnist\benchmarks> python kuzushiji_mnist_knn.py
Fitting KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski',
           metric_params=None, n_jobs=-1, n_neighbors=4, p=2,
           weights='distance')
Evaluating KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski',
           metric_params=None, n_jobs=-1, n_neighbors=4, p=2,
           weights='distance')
Test accuracy: 0.921
```

Besides, the header of `benchmarks/kuzushiji_mnist_knn.py` falsely states that the accuracy is `97.4%`.